### PR TITLE
Refactor GitHub Actions workflow for dispatching dependent workflows

### DIFF
--- a/.github/workflows/dispatch-dependent-workflows.yml
+++ b/.github/workflows/dispatch-dependent-workflows.yml
@@ -1,9 +1,5 @@
 name: Dispatch Dependent Workflows
-on:
-  workflow_dispatch:
-  push:
-    branches:
-      - 'main'
+on: [workflow_dispatch, push]
 
 run-name: "Dispatch Dependent Workflows"
 
@@ -16,4 +12,5 @@ jobs:
         with:
           token: '${{ secrets.DEPENDENT_REPO_TOKEN }}'
           repository: '${{ secrets.DEPENDENT_REPO }}'
-          event-type: 'Linktree-Clone Main Updated'
+          event-type: 'linktree-clone-commit'
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "repo": "${{ github.repository }}"}'


### PR DESCRIPTION
- Simplified event triggers to use an array format for workflow dispatch and push events.
- Updated event type to 'linktree-clone-commit' and added client payload with repository details.