### PR TITLE
Load config and converted_media with readFile instead of dynamic import

### DIFF
--- a/src/components/Instagram/LinkInstagram.stories.tsx
+++ b/src/components/Instagram/LinkInstagram.stories.tsx
@@ -1,4 +1,4 @@
-import { loadConvertedMediaAsync } from "@/pages/index/+data";
+import { loadConvertedMediaAsync } from "@/util/load-data";
 import LinkInstagram from "@components/Instagram/LinkInstagram";
 import type { Meta, StoryObj } from "@storybook/react";
 
@@ -24,7 +24,7 @@ export const Primary: Story = {
   args: {
     username: "example",
     title: "Instagram: @example",
-    images: await loadConvertedMediaAsync(),
+    images: await loadConvertedMediaAsync("data/converted_media.json"),
     imageBaseUrl: "/media",
     followers: 14123124123,
   },

--- a/src/pages/index/+Page.tsx
+++ b/src/pages/index/+Page.tsx
@@ -73,7 +73,7 @@ export default function MainPage() {
         </div>
       </div>
       {/* copyright */}
-      {metadata.copyrightText ? (
+      {metadata?.copyrightText ? (
         <div className="text-center text-sm text-white opacity-50 py-2">
           &copy; {new Date().getFullYear()} {metadata.copyrightText}
         </div>

--- a/src/pages/index/+data.ts
+++ b/src/pages/index/+data.ts
@@ -1,5 +1,4 @@
-import type { ConfigData, ConvertedMediaData } from "@/types";
-import { deepCamelCaseKeys } from "@/util/deep-camel-case-keys";
+import { loadConfigAsync, loadConvertedMediaAsync } from "@/util/load-data";
 import path from "path";
 
 export { data };
@@ -8,25 +7,6 @@ export type Data = Awaited<ReturnType<typeof data>>;
 const dataPath = path.resolve(import.meta.env.DATA_PATH ?? "data");
 const configPath = `${dataPath}/config.json`;
 const convertedMediaPath = `${dataPath}/converted_media.json`;
-// TODO make public path dynamic for dev purposes
-// const publicPath = path.resolve(import.meta.env.PUBLIC_PATH ?? "public");
-
-// Dynamic data loading functions (for client-side updates)
-const loadConfigAsync = async (
-  path: string = configPath,
-): Promise<ConfigData> => {
-  const response = await import(/* @vite-ignore */ path);
-
-  return response.default;
-};
-
-export const loadConvertedMediaAsync = async (
-  path: string = convertedMediaPath,
-): Promise<ConvertedMediaData> => {
-  const response = await import(/* @vite-ignore */ path);
-
-  return deepCamelCaseKeys(response.default);
-};
 
 async function data() {
   const config = await loadConfigAsync(configPath);

--- a/src/util/load-data.ts
+++ b/src/util/load-data.ts
@@ -1,0 +1,15 @@
+import type { ConfigData, ConvertedMediaData } from "@/types";
+import { deepCamelCaseKeys } from "@/util/deep-camel-case-keys";
+import { readFile } from "fs/promises";
+
+export async function loadConfigAsync(filePath: string): Promise<ConfigData> {
+  const raw = await readFile(filePath, "utf-8");
+  return JSON.parse(raw) as ConfigData;
+}
+
+export async function loadConvertedMediaAsync(
+  filePath: string,
+): Promise<ConvertedMediaData> {
+  const raw = await readFile(filePath, "utf-8");
+  return deepCamelCaseKeys(JSON.parse(raw)) as ConvertedMediaData;
+}


### PR DESCRIPTION
The Vike build failed with `TypeError [ERR_IMPORT_ATTRIBUTE_MISSING]` when importing `config.json` and `converted_media.json`. Node ESM requires an import attribute for JSON when using dynamic `import()`, and that cannot be supplied with a variable path.

This PR adds `src/util/load-data.ts` and loads both files via `fs.promises.readFile` and `JSON.parse` at build time. `+data.ts` now uses that util and only exports `data` and `Data`, so Vike's no-side-exports rule is satisfied. The Storybook story imports `loadConvertedMediaAsync` from the util. The site remains static; data is still read only at build time.

The main page also guards the copyright block with optional chaining (`metadata?.copyrightText`) so the build does not crash when `config.json` omits `metadata`.