### PR TITLE
Fix: make converted-media loader tolerate a missing file

### DIFF
--- a/src/util/load-data.ts
+++ b/src/util/load-data.ts
@@ -10,6 +10,16 @@ export async function loadConfigAsync(filePath: string): Promise<ConfigData> {
 export async function loadConvertedMediaAsync(
   filePath: string,
 ): Promise<ConvertedMediaData> {
-  const raw = await readFile(filePath, "utf-8");
+  let raw: string;
+  try {
+    raw = await readFile(filePath, "utf-8");
+  } catch (err) {
+    // Decoupled from the Instagram fetch pipeline: when no converted media
+    // has been supplied, build with an empty set instead of failing.
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw err;
+  }
   return deepCamelCaseKeys(JSON.parse(raw)) as ConvertedMediaData;
 }


### PR DESCRIPTION
Follow-up to #50. The decoupling change to `loadConvertedMediaAsync` was accidentally left unstaged and never committed, so `main` dropped the committed media but the loader still threw `ENOENT` on a missing `converted_media.json` — the deploy build would fail.

This returns an empty set on `ENOENT` so the site builds without committed Instagram media.

Verified: `pnpm build` succeeds with no media data present.

https://claude.ai/code/session_01UK1xhWrswuLMkdzHNhJr11

---
_Generated by [Claude Code](https://claude.ai/code/session_01UK1xhWrswuLMkdzHNhJr11)_